### PR TITLE
fix: timeouts block parsing wrong time units when module used externally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 - Include GatewayLoadbalancer type to the complete example
 
+## [1.0.2] - 2023-11-22
+- fix: timeouts block parsing wrong units when module is used in others modules
+
 ## [1.0.1] - 2023-10-31
 - fix: timeouts block to be more dynamic within the endpoints block
 - feat: showcased usage of auto_accept
@@ -23,7 +26,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Description
 - feat: Initial code commit
 
-[Unreleased]: https://github.com/boldlink/terraform-aws-vpc-endpoints/compare/1.0.0...HEAD
+[Unreleased]: https://github.com/boldlink/terraform-aws-vpc-endpoints/compare/1.0.2...HEAD
 
+[1.0.2]: https://github.com/boldlink/terraform-aws-vpc-endpoints/releases/tag/1.0.2
+[1.0.1]: https://github.com/boldlink/terraform-aws-vpc-endpoints/releases/tag/1.0.1
 [1.0.0]: https://github.com/boldlink/terraform-aws-vpc-endpoints/releases/tag/1.0.0
 [0.1.0]: https://github.com/boldlink/terraform-aws-vpc-endpoints/releases/tag/0.1.0

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ module "minimum_vpc_endpoints" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.23.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.26.0 |
 
 ## Modules
 

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -25,7 +25,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.23.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.26.0 |
 
 ## Modules
 

--- a/examples/minimum/README.md
+++ b/examples/minimum/README.md
@@ -26,7 +26,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.23.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.26.0 |
 
 ## Modules
 

--- a/examples/minimum/main.tf
+++ b/examples/minimum/main.tf
@@ -10,6 +10,10 @@ module "minimum_vpc_endpoints" {
       name              = "s3"
       route_table_ids   = flatten(local.route_table_ids)
       policy            = data.aws_iam_policy_document.s3_endpoint_policy.json
+
+      timeouts = {
+        create = "15m"
+      }
     }
   ]
 }

--- a/main.tf
+++ b/main.tf
@@ -38,10 +38,13 @@ resource "aws_vpc_endpoint" "endpoint" {
     }
   }
 
-  timeouts {
-    create = try(var.vpc_endpoints[count.index]["timeouts"]["create"], "10m")
-    update = try(var.vpc_endpoints[count.index]["timeouts"]["update"], "10m")
-    delete = try(var.vpc_endpoints[count.index]["timeouts"]["delete"], "10m")
+  dynamic "timeouts" {
+    for_each = try([var.vpc_endpoints[count.index]["timeouts"]], [])
+    content {
+      create = try(timeouts.value.create, null)
+      update = try(timeouts.value.update, null)
+      delete = try(timeouts.value.delete, null)
+    }
   }
 
   tags = merge(


### PR DESCRIPTION
# Description

This PR was created to fix timeouts block which resulted in parsing the wrong timeouts units, `D` when the module is used externally

## Features/Fixes/Patches/Changes list:

Please check the [CHANGELOG.md](https://github.com/boldlink/terraform-aws-vpc-endpoints/blob/fix/timeouts-block/CHANGELOG.md#102---2023-11-22)

## Checklists:
<!-- You can erase any parts of this template not applicable to your Pull Request. -->
### PR Owners Checklist:
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Have you checked there aren't open [Pull Requests](../../../pulls) of upstream or parallel code that will cause conflicts?
* [ ] Have you updated the `CHANGELOG.md`?
* [ ] Have you updated the `README.md`(s)?
* [ ] OWNER: Does your submission pass?
    * [ ] Pre-commit (attach logs/print screen to this PR)
    * [ ] Checkov/terrascan (attach logs/print screen to this PR)
    * [ ] Terraform resources examples build/destroy successfully with Terraform 0.14.11 minimum?
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] First PR? Have you deleted `## How to use this template...` from the root `.README.md`?

### PR Reviewers Checklists?
* [ ] Are all your comments/changes resolved?
* [ ] Are you happy with the OWNER checklists and additional information provided?
* [ ] Does your review tests pass?
    * [ ] Terraform resources examples build/destroy successfully with Terraform 0.14.11 minimum?
